### PR TITLE
Upgrade target framework from net7.0 to net10.0

### DIFF
--- a/ci-cd-demo.csproj
+++ b/ci-cd-demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
I am currently following your Udemy course, “CI/CD with TeamCity From Beginner to Advanced.”

I encountered an error while running the project. It wasn’t a major issue—it was related to the .NET version. My system has .NET 10.0 installed, whereas the project in the course uses .NET 7.0.

There are two possible solutions:
1. Downgrade my .NET version from 10.0 to 7.0
2. Update the project to use the newer .NET version

I believe the second option is better, especially for beginners who are learning with the latest tools.

old error:
<img width="1033" height="342" alt="image" src="https://github.com/user-attachments/assets/29b954c2-f611-4f41-8ce7-0ef2f8de60c4" />


after fix: 
<img width="924" height="385" alt="image" src="https://github.com/user-attachments/assets/97f9d197-8d8f-41bb-97a5-734ad7043d5a" />
